### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ information.
 consider using instead:
 
 ``` sh
-$ brew install emacs-plus --HEAD --with-natural-title-bars
+$ brew install emacs-plus --HEAD --with-natural-title-bar
 ```
 
 *Note:* after you have completed the [install process](#install) below, it is


### PR DESCRIPTION
There is no `--with-natural-title-bars` option when compiling emacs-plus from the brew formula, the correct option should be `--with-natural-title-bar`. Not sure if it's a typo or if it has changed but I thought updating the README would avoid some confusion.